### PR TITLE
Fix yarn install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Agent Server for GraphAI
 # Install
 
 ```
-yarn run install
+yarn install
 ```
 
 ### run server
@@ -27,4 +27,3 @@ yarn run server
 # config
 
 in src/config.ts
-


### PR DESCRIPTION
The error occured when I tried `yarn run install`.
After that I tried `yarn install` then it was succeed and that is why I  send this Pull Request.

```
$ yarn run install
yarn run v1.22.21
error Command "install" not found.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

```
$ yarn install    
yarn install v1.22.21
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
warning replicate@1.0.1: The engine "git" appears to be invalid.
warning replicate@0.31.1: The engine "git" appears to be invalid.
[3/4] 🔗  Linking dependencies...
[4/4] 🔨  Building fresh packages...
✨  Done in 8.15s.
(base) 
```