### PR TITLE
chore: upgrade actions/cache from v4 to v5

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -27,7 +27,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'
       - name: Cache node_modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: node_modules
           key: node-modules-${{ matrix.node-version }}-${{ matrix.os }}-${{ hashFiles('yarn.lock') }}


### PR DESCRIPTION
## Summary
- **actions/cache v4 → v5**: Node.js 20 deprecation warning の解消

## Test plan
- [ ] CI で Node.js 20 deprecation warning が消えることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)